### PR TITLE
Add ability to use fabfile.yaml.inc + fixing directory traversal and merging multiple yaml configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,10 @@ On systems with a non-bash environment like lshell try the following settings in
         # add custom parameters to git-commands:
         gitOptions:
           pull:
-            -- <parameter 1>
-            -- <parameter 2>
+            - <parameter 1>
+            - <parameter 2>
+            # e.g.:
+            - --rebase
 
       hostB:
         # you can "include" the configuration of another host via inheritsFrom


### PR DESCRIPTION
First one is easy: fabfile.yaml.inc will also be parsed with the benefit that those files aren't served by webservers.

Second is a bit more complex. Fabalicious will traverse two directories up when looking for yaml configuration files and will merge the configuration files found. The idea behind this is to add a default docker fabfile.yaml to the multibasebox with all 'default' docker tasks. Right now we define hproxy reload, run etc in every project. This removes some code duplication in the yaml files and will make it easier to create a new configurations. I will add a branch to multibasebox with a yaml file.

(I started stupid because i started working on master and merged back my changes to develop for this pull requests. Don't ask me why but some of your commits on master have never made it to develop those are included now... )  